### PR TITLE
Upgraded dependencies to align with newer releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 		<dependency>
 			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
-			<version>1.4.9</version>
+			<version>1.4.10</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -73,14 +73,14 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.22</version>
+			<version>1.7.25</version>
 		</dependency>
 
 		<!-- Prevent logging -->
 		<dependency>
 		    <groupId>org.slf4j</groupId>
 		    <artifactId>slf4j-nop</artifactId>
-		    <version>1.7.22</version>
+		    <version>1.7.25</version>
 		    <scope>provided</scope>
 		</dependency>
 		
@@ -94,14 +94,14 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.8.0</version>
+			<version>2.8.2</version>
 			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 		    <groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>
-			<version>1.12</version>
+			<version>1.14</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -140,14 +140,14 @@
 		<dependency>
 			<groupId>com.sun.jersey</groupId>
 			<artifactId>jersey-core</artifactId>
-			<version>1.19.3</version>
+			<version>1.19.4</version>
 			<scope>provided</scope>
 		</dependency>
 		
 		<dependency>
 		    <groupId>com.google.guava</groupId>
 		    <artifactId>guava</artifactId>
-		    <version>20.0</version>
+		    <version>23.0</version>
 		    <scope>provided</scope>
 		</dependency>
 		
@@ -155,7 +155,7 @@
 		<dependency>
 		    <groupId>ch.qos.logback</groupId>
 		    <artifactId>logback-classic</artifactId>
-		    <version>1.1.8</version>
+		    <version>1.2.3</version>
 		</dependency>
 		
 		<!-- For thread-safety annotations -->


### PR DESCRIPTION
Hi - I just took time to upgraded a few dependencies that were too old and had more mature releases. Some of the dependencies still have a newer version but they are either beta or for specific Java edition which may break backward compatibility.
